### PR TITLE
fix(perfect_drone_sim): Add missing pcl_conversions dependency

### DIFF
--- a/mars_uav_sim/perfect_drone_sim/ros/ros2.CMakeLists.txt
+++ b/mars_uav_sim/perfect_drone_sim/ros/ros2.CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(visualization_msgs REQUIRED)
 find_package(marsim_render REQUIRED)
 find_package(mars_quadrotor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(pcl_conversions REQUIRED)
 
 # Other packages
 find_package(Eigen3 REQUIRED)
@@ -63,6 +64,7 @@ set(dependencies
         nav_msgs
         visualization_msgs
         tf2_ros
+        pcl_conversions
 )
 
 add_executable(perfect_drone_node

--- a/mars_uav_sim/perfect_drone_sim/ros/ros2.package.xml
+++ b/mars_uav_sim/perfect_drone_sim/ros/ros2.package.xml
@@ -12,6 +12,7 @@
     <depend>std_msgs</depend>
     <depend>mars_quadrotor_msgs</depend>
     <depend>marsim_render</depend>
+    <depend>pcl_conversions</depend>
     <export>
         <build_type>ament_cmake</build_type>
     </export>


### PR DESCRIPTION
The package failed to build on ROS 2 Humble, reporting a 'pcl_conversions.h: No such file or directory' error. This was caused by an undeclared dependency on the pcl_conversions package.

This commit resolves the issue by updating the ROS 2 build templates to properly declare this dependency:

- Adds '<depend>pcl_conversions</depend>' to the 'ros2.package.xml' template.
- Ensures 'pcl_conversions' is found and linked in the 'ros2.CMakeLists.txt' template.

These changes allow the compiler to locate the necessary headers and libraries, enabling a successful build of the package.